### PR TITLE
Activate extension when editor has json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsoncrack-vscode",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "displayName": "JSON Crack",
   "description": "Seamlessly visualize your JSON data instantly into graphs.",
   "license": "MIT",
@@ -52,7 +52,7 @@
       "editor/title": [
         {
           "command": "jsoncrack-vscode.start",
-          "when": "resourceExtname == .json",
+          "when": "resourceExtname == .json || editorLangId == json",
           "group": "navigation"
         }
       ]


### PR DESCRIPTION
The current version of the extension is only activated when editing a json file stored on disk. This PR activates the extension whenever json content is edited (e.g., in a temporary editor window that has not been saved) based on the editor language ID.