### PR TITLE
Command to create JSON Crack from specific content

### DIFF
--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -2,13 +2,13 @@ import * as vscode from "vscode";
 import { createWebviewPanel } from "./webview";
 
 export function activate(context: vscode.ExtensionContext) {
-  const cmd = "jsoncrack-vscode.start";
-  const init = () => initJsonCrack(context);
-  const disposable = vscode.commands.registerCommand(cmd, init);
-  context.subscriptions.push(disposable);
+  context.subscriptions.push(
+    vscode.commands.registerCommand("jsoncrack-vscode.start", () => createWebviewForActiveEditor(context)),
+    vscode.commands.registerCommand("jsoncrack-vscode.start.specific", (content?: string) => createWebviewForContent(context, content)),
+  );
 }
 
-async function initJsonCrack(context: vscode.ExtensionContext) {
+async function createWebviewForActiveEditor(context: vscode.ExtensionContext) {
   const panel = createWebviewPanel(context);
   const editor = vscode.window.activeTextEditor;
 
@@ -36,6 +36,20 @@ async function initJsonCrack(context: vscode.ExtensionContext) {
   };
 
   panel.onDidDispose(disposer, null, context.subscriptions);
+}
+
+/**
+ * Renders a readonly diagram from a string
+ * @param context ExtensionContext
+ * @param content JSON content as a string
+ */
+function createWebviewForContent(context?: vscode.ExtensionContext, content?: string): any {
+  if (context && content) {
+    const panel = createWebviewPanel(context);
+    panel.webview.postMessage({
+      json: content,
+    });
+  }
 }
 
 // This method is called when your extension is deactivated

--- a/package.json
+++ b/package.json
@@ -45,9 +45,20 @@
           "light": "./assets/icon.svg",
           "dark": "./assets/icon.svg"
         }
+      },
+      {
+        "command": "jsoncrack-vscode.start.specific",
+        "title": "Enable JSON Crack visualization for specific file",
+        "category": "menubar"
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "jsoncrack-vscode.start",
+          "when": "never"
+        }
+      ],
       "editor/title": [
         {
           "command": "jsoncrack-vscode.start",


### PR DESCRIPTION
I want to make use of JSON Crack from another extension, but don't want it based off the active editor.

I have created `jsoncrack-vscode.start.specific`, which allows other extensions to call it with a JSON string, which is then populated into a new webview.

It is called like so:

```ts
commands.executeCommand(`jsoncrack-vscode.start.specific`, myJsonDiagram)
```